### PR TITLE
npmignore: ignore src only in project root

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
 android/.idea
 android/build
 rn-indy-sdk-1.0.0.tgz
-src
+/src/


### PR DESCRIPTION
Ignoring it globally causes android src to be excluded
from the packed tarball

Signed-off-by: Gaurav Narula <gnarula94@gmail.com>