### PR TITLE
Bump indy version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,7 +92,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'org.hyperledger:indy:1.8.3'
+    implementation 'org.hyperledger:indy:1.14.2'
     implementation 'com.google.code.gson:gson:2.8.5'
 }
 


### PR DESCRIPTION
Sovrin's maven repo is down at the moment but the latest indy version right now is 1.14.2 and was released as recently as January.

Please note that libindy > 1.12.0 uses Android NDK 20 and API v21. As a result, libgnustl_shared needs to be replaced with libc++_shared in your jniLibs directory