### PR TITLE
iOS: Fix method names and parse JSON response

### DIFF
--- a/ios/IndySdk.m
+++ b/ios/IndySdk.m
@@ -176,11 +176,11 @@ RCT_EXTERN_METHOD(parseGetCredDefResponse: (NSString *)getCredDefResponse
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(buildGetAttribRequest: (NSString *)submitterDid
+RCT_EXTERN_METHOD(buildGetAttribRequest: (nullable NSString *)submitterDid
                   targetDid:(NSString *)targetDid
-                  raw:(NSString *)raw
-                  hash:(NSString *)hash
-                  enc:(NSString *)enc
+                  raw:(nullable NSString *)raw
+                  hash:(nullable NSString *)hash
+                  enc:(nullable NSString *)enc
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/ios/IndySdk.swift
+++ b/ios/IndySdk.swift
@@ -260,11 +260,11 @@ class IndySdk : NSObject {
       IndyLedger.parseGetCredDefResponse(getCredDefResponse, completion: completionWithStringPair(resolve, reject))
     }
     
-    @objc func builGetAttribRequest(_ submitterDid: String,
+    @objc func buildGetAttribRequest(_ submitterDid: String?,
                                     targetDid: String,
-                                    raw: String,
-                                    hash: String,
-                                    enc: String,
+                                    raw: String?,
+                                    hash: String?,
+                                    enc: String?,
                                     resolver resolve: @escaping RCTPromiseResolveBlock,
                                     rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         IndyLedger.buildGetAttribRequest(withSubmitterDid: submitterDid, targetDID: targetDid, raw: raw, hash: hash, enc: enc, completion: completionWithString(resolve, reject))

--- a/src/index.js
+++ b/src/index.js
@@ -444,20 +444,21 @@ export default {
 
   async buildGetCredDefRequest(submitterDid: Did, id: string): Promise<LedgerRequestResult> {
     if (Platform.OS === 'ios') {
-      return IndySdk.buildGetCredDefRequest(submitterDid, id)
+      return JSON.parse(await IndySdk.buildGetCredDefRequest(submitterDid, id));
     }
     return JSON.parse(await IndySdk.buildGetCredDefRequest(submitterDid, id))
   },
 
   async parseGetCredDefResponse(getCredDefResponse: LedgerRequestResult): Promise<[CredDefId, CredDef]> {
     if (Platform.OS === 'ios') {
-      return IndySdk.parseGetCredDefResponse(JSON.stringify(getCredDefResponse))
+      const [credDefId, credDef ] = await IndySdk.parseGetCredDefResponse(JSON.stringify(getCredDefResponse))
+      return [credDefId, JSON.parse(credDef)];
     }
     const [credDefId, credDef] = await IndySdk.parseGetCredDefResponse(JSON.stringify(getCredDefResponse))
     return [credDefId, JSON.parse(credDef)]
   },
 
-  proverCreateMasterSecret(wh: WalletHandle, masterSecretId: ?MasterSecretId): Promise<MasterSecretId> {
+  async proverCreateMasterSecret(wh: WalletHandle, masterSecretId: ?MasterSecretId): Promise<MasterSecretId> {
     if (Platform.OS === 'ios') {
       return IndySdk.proverCreateMasterSecret(masterSecretId, wh)
     }
@@ -472,13 +473,14 @@ export default {
     masterSecretId: MasterSecretId
   ): Promise<[CredReq, CredReqMetadata]> {
     if (Platform.OS === 'ios') {
-      return IndySdk.proverCreateCredentialReq(
+      const [credReq, credReqMetadata] = await IndySdk.proverCreateCredentialReq(
         JSON.stringify(credOffer),
         JSON.stringify(credDef),
         proverDid,
         masterSecretId,
         wh
-      )
+      );
+      return [JSON.parse(credReq), JSON.parse(credReqMetadata)];
     }
     const [credReq, credReqMetadata] = await IndySdk.proverCreateCredentialReq(
       wh,

--- a/src/index.js
+++ b/src/index.js
@@ -443,17 +443,10 @@ export default {
   },
 
   async buildGetCredDefRequest(submitterDid: Did, id: string): Promise<LedgerRequestResult> {
-    if (Platform.OS === 'ios') {
-      return JSON.parse(await IndySdk.buildGetCredDefRequest(submitterDid, id));
-    }
     return JSON.parse(await IndySdk.buildGetCredDefRequest(submitterDid, id))
   },
 
   async parseGetCredDefResponse(getCredDefResponse: LedgerRequestResult): Promise<[CredDefId, CredDef]> {
-    if (Platform.OS === 'ios') {
-      const [credDefId, credDef ] = await IndySdk.parseGetCredDefResponse(JSON.stringify(getCredDefResponse))
-      return [credDefId, JSON.parse(credDef)];
-    }
     const [credDefId, credDef] = await IndySdk.parseGetCredDefResponse(JSON.stringify(getCredDefResponse))
     return [credDefId, JSON.parse(credDef)]
   },
@@ -479,8 +472,8 @@ export default {
         proverDid,
         masterSecretId,
         wh
-      );
-      return [JSON.parse(credReq), JSON.parse(credReqMetadata)];
+      )
+      return [JSON.parse(credReq), JSON.parse(credReqMetadata)]
     }
     const [credReq, credReqMetadata] = await IndySdk.proverCreateCredentialReq(
       wh,


### PR DESCRIPTION
* Fixed a typo in `buildGetAttribRequest`
* Made submitterDID, raw, hash, enc nullable in `buildGetAttribRequest`
* Parse JSON response for `buildGetCredDefRequest`, `parseGetCredDefResponse` and `proverCreateCredentialReq` before returning it