### PR TITLE
Add iOS error hangling on JS side

### DIFF
--- a/ios/IndySdk.swift
+++ b/ios/IndySdk.swift
@@ -546,18 +546,18 @@ class IndySdk : NSObject {
     
     struct ErrorMessage: Codable {
       var message: String
-      var code: Int
+      var indyCode: Int
     }
     
     func createJsonError(_ error: Error, _ code: Int) -> String! {
       let jsonEncoder = JSONEncoder()
       do {
-        let message = "IndyBridge: \(String(describing: error))"
-        let jsonData = try jsonEncoder.encode(ErrorMessage(message: message, code: code))
+        let message = "IndySdk: \(String(describing: error))"
+        let jsonData = try jsonEncoder.encode(ErrorMessage(message: message, indyCode: code))
         return String(data: jsonData, encoding: .utf8)
       } catch {
         // This code can perhaps replace implementation above
-        return "{\"message\": \"IndyBridge: \(String(describing: error))\"}"
+        return "{\"message\": \"IndySdk: \(String(describing: error))\"}"
       }
     }
     

--- a/src/index.js
+++ b/src/index.js
@@ -620,6 +620,66 @@ const indy = {
   },
 }
 
+const indyErrors = {
+  100: 'CommonInvalidParam1',
+  101: 'CommonInvalidParam2',
+  102: 'CommonInvalidParam3',
+  103: 'CommonInvalidParam4',
+  104: 'CommonInvalidParam5',
+  105: 'CommonInvalidParam6',
+  106: 'CommonInvalidParam7',
+  107: 'CommonInvalidParam8',
+  108: 'CommonInvalidParam9',
+  109: 'CommonInvalidParam10',
+  110: 'CommonInvalidParam11',
+  111: 'CommonInvalidParam12',
+  112: 'CommonInvalidState',
+  113: 'CommonInvalidStructure',
+  114: 'CommonIOError',
+  115: 'CommonInvalidParam13',
+  116: 'CommonInvalidParam14',
+  200: 'WalletInvalidHandle',
+  201: 'WalletUnknownTypeError',
+  202: 'WalletTypeAlreadyRegisteredError',
+  203: 'WalletAlreadyExistsError',
+  204: 'WalletNotFoundError',
+  205: 'WalletIncompatiblePoolError',
+  206: 'WalletAlreadyOpenedError',
+  207: 'WalletAccessFailed',
+  208: 'WalletInputError',
+  209: 'WalletDecodingError',
+  210: 'WalletStorageError',
+  211: 'WalletEncryptionError',
+  212: 'WalletItemNotFound',
+  213: 'WalletItemAlreadyExists',
+  214: 'WalletQueryError',
+  300: 'PoolLedgerNotCreatedError',
+  301: 'PoolLedgerInvalidPoolHandle',
+  302: 'PoolLedgerTerminated',
+  303: 'LedgerNoConsensusError',
+  304: 'LedgerInvalidTransaction',
+  305: 'LedgerSecurityError',
+  306: 'PoolLedgerConfigAlreadyExistsError',
+  307: 'PoolLedgerTimeout',
+  308: 'PoolIncompatibleProtocolVersion',
+  309: 'LedgerNotFound',
+  400: 'AnoncredsRevocationRegistryFullError',
+  401: 'AnoncredsInvalidUserRevocId',
+  404: 'AnoncredsMasterSecretDuplicateNameError',
+  405: 'AnoncredsProofRejected',
+  406: 'AnoncredsCredentialRevoked',
+  407: 'AnoncredsCredDefAlreadyExistsError',
+  500: 'UnknownCryptoTypeError',
+  600: 'DidAlreadyExistsError',
+  700: 'PaymentUnknownMethodError',
+  701: 'PaymentIncompatibleMethodsError',
+  702: 'PaymentInsufficientFundsError',
+  703: 'PaymentSourceDoesNotExistError',
+  704: 'PaymentOperationNotSupportedError',
+  705: 'PaymentExtraFundsError',
+  706: 'TransactionNotAllowedError',
+}
+
 function wrapIndyCallWithErrorHandling(func) {
   return async (...args) => {
     // Wrap try/catch around indy func
@@ -635,6 +695,21 @@ function wrapIndyCallWithErrorHandling(func) {
         parse = JSON.parse(e.message)
       } catch {
         throw e
+      }
+
+      if (Platform.OS === 'ios') {
+        const { indyCode, message } = parse
+        if (!isNaN(indyCode) && indyErrors.hasOwnProperty(indyCode)) {
+          const indyName = indyErrors[indyCode]
+          const indyErrorFromIOS = {
+            name: 'IndyError',
+            message,
+            indyCode: indyCode,
+            indyName: indyName,
+            indyCurrentErrorJson: null,
+          }
+          throw indyErrorFromIOS
+        }
       }
 
       throw parse


### PR DESCRIPTION
No changes in Aries JS framework needed. I know we try to preserve Node.js wrapper API, but I think the following attributes are just good enough:

```json
{
  "name": "IndyError",
  "indyCode": 203,
  "indyName": "WalletAlreadyExistsError",
  "message": "This can contain anything, but idealy it'll contain original error message from given platofm"
}
```

Other attributes could be optional. The `message` attribute could be unreliable so it also could be just optional.
