### PR TITLE
Add logging of unhandled exceptions from calls to libindy

### DIFF
--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ExecutionException;
 @TargetApi(24)
 public class IndySdkModule extends ReactContextBaseJavaModule {
 
+    private static final String TAG = "IndySdk";
     private final ReactApplicationContext reactContext;
 
     private Map<Integer, Wallet> walletMap;
@@ -756,7 +757,11 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
                     // https://github.com/hyperledger/indy-sdk/blob/bafa3bbcca2f7ef4cf5ae2aca01b1dbf7286b924/wrappers/java/src/main/java/org/hyperledger/indy/sdk/IndyException.java#L71-L83
                     indyMessage = indyException.getSdkMessage();
                     indyBacktrace = indyException.getSdkBacktrace();
+                } else {
+                    Log.e(TAG, "Unhandled non IndyException", e);
                 }
+            } else {
+                Log.e(TAG, "Unhandled non ExecutionException", e);
             }
         }
 


### PR DESCRIPTION
It would be perhaps even better to re-throw the exception, but this error handling is like walking on thin ice for me right now so I don't want to do more than it's necessary.