### PR TITLE
Android - Schema, Credential Definition, TAA & Issue Credentials

### DIFF
--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -34,6 +34,7 @@ import org.hyperledger.indy.sdk.anoncreds.Anoncreds;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateSchemaResult;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateAndStoreCredentialDefResult;
+import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateCredentialResult;
 import org.hyperledger.indy.sdk.blob_storage.BlobStorageReader;
 import org.hyperledger.indy.sdk.crypto.Crypto;
 import org.hyperledger.indy.sdk.crypto.CryptoResults;
@@ -548,7 +549,7 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
         }
     }
-
+    
     // anoncreds
 
     @ReactMethod
@@ -573,6 +574,22 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             WritableArray response = new WritableNativeArray();
             response.pushString(schemaResult.getCredDefId());
             response.pushString(schemaResult.getCredDefJson());
+            promise.resolve(response);
+        } catch(Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+    
+    @ReactMethod
+    public void issuerCreateCredential(int walletHandle, String credOffer, String credReq, String credvalues, String revRegId, int blobStorageReaderHandle, Promise promise) {
+        try {
+            Wallet wallet = walletMap.get(walletHandle);
+            IssuerCreateCredentialResult  createCredResult = Anoncreds.issuerCreateCredential(wallet, credOffer, credReq, credvalues, revRegId, blobStorageReaderHandle).get();
+            WritableArray response = new WritableNativeArray();
+            response.pushString(createCredResult.getCredentialJson());
+            response.pushString(createCredResult.getRevocId());
+            response.pushString(createCredResult.getRevocRegDeltaJson());
             promise.resolve(response);
         } catch(Exception e) {
             IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);

--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -33,6 +33,7 @@ import org.hyperledger.indy.sdk.ErrorCode;
 import org.hyperledger.indy.sdk.anoncreds.Anoncreds;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateSchemaResult;
+import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateAndStoreCredentialDefResult;
 import org.hyperledger.indy.sdk.crypto.Crypto;
 import org.hyperledger.indy.sdk.crypto.CryptoResults;
 import org.hyperledger.indy.sdk.did.Did;
@@ -457,6 +458,17 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void buildCredDefRequest(String submitterDid, String data, Promise promise) {
+        try {
+            String request = Ledger.buildCredDefRequest(submitterDid, data).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
     public void buildGetCredDefRequest(String submitterDid, String id, Promise promise) {
         try {
             String request = Ledger.buildGetCredDefRequest(submitterDid, id).get();
@@ -556,6 +568,21 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             WritableArray response = new WritableNativeArray();
             response.pushString(schemaResult.getSchemaId());
             response.pushString(schemaResult.getSchemaJson());
+            promise.resolve(response);
+        } catch(Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+    
+    @ReactMethod
+    public void issuerCreateAndStoreCredentialDef(int walletHandle, String issuerDid, String schemaJson, String tag, String signatureType, String configJson, Promise promise) {
+        try {
+            Wallet wallet = walletMap.get(walletHandle);
+            IssuerCreateAndStoreCredentialDefResult schemaResult = Anoncreds.issuerCreateAndStoreCredentialDef(wallet, issuerDid, schemaJson, tag, signatureType, configJson).get();
+            WritableArray response = new WritableNativeArray();
+            response.pushString(schemaResult.getCredDefId());
+            response.pushString(schemaResult.getCredDefJson());
             promise.resolve(response);
         } catch(Exception e) {
             IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);

--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -33,7 +33,6 @@ import org.hyperledger.indy.sdk.ErrorCode;
 import org.hyperledger.indy.sdk.anoncreds.Anoncreds;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateSchemaResult;
-import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateCredentialResult;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateAndStoreCredentialDefResult;
 import org.hyperledger.indy.sdk.blob_storage.BlobStorageReader;
 import org.hyperledger.indy.sdk.crypto.Crypto;
@@ -550,17 +549,6 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
         }
     }
 
-    @ReactMethod
-    public void buildGetAcceptanceMechanismsRequest(String submitterDid, int timestamp, String version, Promise promise) {
-        try {
-            String request = Ledger.buildGetAcceptanceMechanismsRequest(submitterDid, timestamp, version).get();
-            promise.resolve(request);
-        } catch (Exception e) {
-            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-        }
-    }
-
     // anoncreds
 
     @ReactMethod
@@ -597,22 +585,6 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
         try {
             Wallet wallet = walletMap.get(walletHandle);
             String response = Anoncreds.issuerCreateCredentialOffer(wallet, credDefId).get();
-            promise.resolve(response);
-        } catch(Exception e) {
-            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-        }
-    }
-    
-    @ReactMethod
-    public void issuerCreateCredential(int walletHandle, String credOfferJson, String credReqJson, String credValuesJson, String revRegId, int blobStorageReaderHandle, Promise promise) {
-        try {
-            Wallet wallet = walletMap.get(walletHandle);
-            IssuerCreateCredentialResult createCredResult = Anoncreds.issuerCreateCredential(wallet, credOfferJson,credReqJson,credValuesJson,revRegId,blobStorageReaderHandle).get();
-            WritableArray response = new WritableNativeArray();
-            response.pushString(createCredResult.getCredentialJson());
-            response.pushString(createCredResult.getRevocId());
-            response.pushString(createCredResult.getRevocRegDeltaJson());
             promise.resolve(response);
         } catch(Exception e) {
             IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);

--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -33,7 +33,9 @@ import org.hyperledger.indy.sdk.ErrorCode;
 import org.hyperledger.indy.sdk.anoncreds.Anoncreds;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateSchemaResult;
+import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateCredentialResult;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateAndStoreCredentialDefResult;
+import org.hyperledger.indy.sdk.blob_storage.BlobStorageReader;
 import org.hyperledger.indy.sdk.crypto.Crypto;
 import org.hyperledger.indy.sdk.crypto.CryptoResults;
 import org.hyperledger.indy.sdk.did.Did;
@@ -589,6 +591,34 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
         }
     }
+    
+    @ReactMethod
+    public void issuerCreateCredentialOffer(int walletHandle, String credDefId, Promise promise) {
+        try {
+            Wallet wallet = walletMap.get(walletHandle);
+            String response = Anoncreds.issuerCreateCredentialOffer(wallet, credDefId).get();
+            promise.resolve(response);
+        } catch(Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+    
+    @ReactMethod
+    public void issuerCreateCredential(int walletHandle, String credOfferJson, String credReqJson, String credValuesJson, String revRegId, int blobStorageReaderHandle, Promise promise) {
+        try {
+            Wallet wallet = walletMap.get(walletHandle);
+            IssuerCreateCredentialResult createCredResult = Anoncreds.issuerCreateCredential(wallet, credOfferJson,credReqJson,credValuesJson,revRegId,blobStorageReaderHandle).get();
+            WritableArray response = new WritableNativeArray();
+            response.pushString(createCredResult.getCredentialJson());
+            response.pushString(createCredResult.getRevocId());
+            response.pushString(createCredResult.getRevocRegDeltaJson());
+            promise.resolve(response);
+        } catch(Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
 
     @ReactMethod
     public void proverCreateMasterSecret(int walletHandle, String masterSecretId, Promise promise) {
@@ -696,6 +726,19 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             ).get();
             promise.resolve(proofJson);
         } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    // blob_storage
+    
+    @ReactMethod
+    public void openBlobStorageReader(String type, String tailsWriterConfig, Promise promise) {
+        try {
+            BlobStorageReader response = BlobStorageReader.openReader(type, tailsWriterConfig).get();
+            promise.resolve(response.getBlobStorageReaderHandle());
+        } catch(Exception e) {
             IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
             promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
         }

--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -32,6 +32,7 @@ import org.hyperledger.indy.sdk.IndyException;
 import org.hyperledger.indy.sdk.ErrorCode;
 import org.hyperledger.indy.sdk.anoncreds.Anoncreds;
 import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults;
+import org.hyperledger.indy.sdk.anoncreds.AnoncredsResults.IssuerCreateSchemaResult;
 import org.hyperledger.indy.sdk.crypto.Crypto;
 import org.hyperledger.indy.sdk.crypto.CryptoResults;
 import org.hyperledger.indy.sdk.did.Did;
@@ -408,6 +409,29 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void signRequest(int walletHandle, String submitterDid, String requestJson, Promise promise) {
+        try {
+            Wallet wallet = walletMap.get(walletHandle);
+            String request = Ledger.signRequest(wallet, submitterDid, requestJson).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void buildSchemaRequest(String submitterDid, String data, Promise promise) {
+        try {
+            String request = Ledger.buildSchemaRequest(submitterDid, data).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
     public void buildGetSchemaRequest(String submitterDid, String id, Promise promise) {
         try {
             String request = Ledger.buildGetSchemaRequest(submitterDid, id).get();
@@ -490,7 +514,54 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void appendTxnAuthorAgreementAcceptanceToRequest(String requestJson, String text, String version, String taaDigest, String mechanism, int time, Promise promise) {
+        try {
+            String request = Ledger.appendTxnAuthorAgreementAcceptanceToRequest(requestJson, text, version, taaDigest, mechanism, time).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void buildGetTxnAuthorAgreementRequest(String submitterDid, String data, Promise promise) {
+        try {
+            String request = Ledger.buildGetTxnAuthorAgreementRequest(submitterDid, data).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
+    public void buildGetAcceptanceMechanismsRequest(String submitterDid, int timestamp, String version, Promise promise) {
+        try {
+            String request = Ledger.buildGetAcceptanceMechanismsRequest(submitterDid, timestamp, version).get();
+            promise.resolve(request);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
     // anoncreds
+
+    @ReactMethod
+    public void issuerCreateSchema(String issuerDid, String name, String version, String attrs, Promise promise) {
+        try {
+            IssuerCreateSchemaResult schemaResult = Anoncreds.issuerCreateSchema(issuerDid, name, version, attrs).get();
+            WritableArray response = new WritableNativeArray();
+            response.pushString(schemaResult.getSchemaId());
+            response.pushString(schemaResult.getSchemaJson());
+            promise.resolve(response);
+        } catch(Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
 
     @ReactMethod
     public void proverCreateMasterSecret(int walletHandle, String masterSecretId, Promise promise) {

--- a/src/index.js
+++ b/src/index.js
@@ -224,12 +224,12 @@ export type CredReqMetadata = {}
  */
 export type RevRegDef = {}
 
-export type RevRegId = string;
-export type CredRevocId = string;
-export type RevocRegDelta = Record<string, unknown>;
+export type RevRegId = string
+export type CredRevocId = string
+export type RevocRegDelta = Record<string, unknown>
 export type TailsWriterConfig = {
-  base_dir: string;
-  uri_pattern: string
+  base_dir: string,
+  uri_pattern: string,
 }
 
 export type Did = string
@@ -430,9 +430,9 @@ const indy = {
 
   async signRequest(wh: WalletHandle, submitterDid: Did, request: LedgerRequest): Promise<LedgerRequest> {
     if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`);
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
-    return JSON.parse(await IndySdk.signRequest(wh, submitterDid, JSON.stringify(request)));
+    return JSON.parse(await IndySdk.signRequest(wh, submitterDid, JSON.stringify(request)))
   },
 
   async buildSchemaRequest(submitterDid: Did, data: string): Promise<LedgerRequest> {
@@ -440,7 +440,7 @@ const indy = {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
 
-    return JSON.parse(await IndySdk.buildSchemaRequest(submitterDid, JSON.stringify(data)));
+    return JSON.parse(await IndySdk.buildSchemaRequest(submitterDid, JSON.stringify(data)))
   },
 
   async buildGetSchemaRequest(submitterDid: Did, id: string): Promise<LedgerRequest> {
@@ -612,11 +612,27 @@ const indy = {
     )
   },
 
-  async appendTxnAuthorAgreementAcceptanceToRequest(request: LedgerRequest, text: string, version: string, taaDigest: string, mechanism: string, time: number): Promise<LedgerRequest> {
+  async appendTxnAuthorAgreementAcceptanceToRequest(
+    request: LedgerRequest,
+    text: string,
+    version: string,
+    taaDigest: string,
+    mechanism: string,
+    time: number
+  ): Promise<LedgerRequest> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
-    return JSON.parse(await IndySdk.appendTxnAuthorAgreementAcceptanceToRequest(JSON.stringify(request), text, version, taaDigest, mechanism, time))
+    return JSON.parse(
+      await IndySdk.appendTxnAuthorAgreementAcceptanceToRequest(
+        JSON.stringify(request),
+        text,
+        version,
+        taaDigest,
+        mechanism,
+        time
+      )
+    )
   },
 
   async buildGetTxnAuthorAgreementRequest(submitterDid: Did, data: string): Promise<LedgerRequest> {
@@ -675,17 +691,31 @@ const indy = {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
 
-    const [schemaId, schema] = await IndySdk.issuerCreateSchema(did, name, version, JSON.stringify(attributes));
-    return [schemaId, JSON.parse(schema)];
+    const [schemaId, schema] = await IndySdk.issuerCreateSchema(did, name, version, JSON.stringify(attributes))
+    return [schemaId, JSON.parse(schema)]
   },
 
-  async issuerCreateAndStoreCredentialDef(wh: WalletHandle, issuerDid: Did, schema: Schema, tag: string, signatureType: string, config: {}): Promise<[CredDef, CredDefId]> {
+  async issuerCreateAndStoreCredentialDef(
+    wh: WalletHandle,
+    issuerDid: Did,
+    schema: Schema,
+    tag: string,
+    signatureType: string,
+    config: {}
+  ): Promise<[CredDef, CredDefId]> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
 
-    const [credDefId, credDef] = await IndySdk.issuerCreateAndStoreCredentialDef(wh, issuerDid, JSON.stringify(schema), tag, signatureType, JSON.stringify(config));
-    return [credDefId, JSON.parse(credDef)];
+    const [credDefId, credDef] = await IndySdk.issuerCreateAndStoreCredentialDef(
+      wh,
+      issuerDid,
+      JSON.stringify(schema),
+      tag,
+      signatureType,
+      JSON.stringify(config)
+    )
+    return [credDefId, JSON.parse(credDef)]
   },
 
   async issuerCreateCredentialOffer(wh: WalletHandle, credDefId: CredDefId): Promise<CredOffer> {
@@ -693,7 +723,7 @@ const indy = {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
 
-    return JSON.parse(await IndySdk.issuerCreateCredentialOffer(wh, credDefId));
+    return JSON.parse(await IndySdk.issuerCreateCredentialOffer(wh, credDefId))
   },
 
   // blob_storage
@@ -703,7 +733,7 @@ const indy = {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
 
-    return JSON.parse(await IndySdk.openBlobStorageReader(type, JSON.stringify(tailsWriterConfig)));
+    return JSON.parse(await IndySdk.openBlobStorageReader(type, JSON.stringify(tailsWriterConfig)))
   },
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -428,7 +428,7 @@ const indy = {
     return JSON.parse(await IndySdk.submitRequest(poolHandle, JSON.stringify(request)))
   },
 
-  async signRequest(wh: WalletHandle, submitterDid: Did, request: LedgerRequest) {
+  async signRequest(wh: WalletHandle, submitterDid: Did, request: LedgerRequest): Promise<LedgerRequest> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`);
     }
@@ -612,21 +612,21 @@ const indy = {
     )
   },
 
-  async appendTxnAuthorAgreementAcceptanceToRequest(request: LedgerRequest, text: string, version: string, taaDigest: string, mechanism: string, time: number): Promise<string> {
+  async appendTxnAuthorAgreementAcceptanceToRequest(request: LedgerRequest, text: string, version: string, taaDigest: string, mechanism: string, time: number): Promise<LedgerRequest> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
-    return JSON.parse(await IndySdk.appendTxnAuthorAgreementAcceptanceToRequest(request, text, version, taaDigest, mechanism, time))
+    return JSON.parse(await IndySdk.appendTxnAuthorAgreementAcceptanceToRequest(JSON.stringify(request), text, version, taaDigest, mechanism, time))
   },
 
-  async buildGetTxnAuthorAgreementRequest(submitterDid: Did, data: string): Promise<string> {
+  async buildGetTxnAuthorAgreementRequest(submitterDid: Did, data: string): Promise<LedgerRequest> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
     return JSON.parse(await IndySdk.buildGetTxnAuthorAgreementRequest(submitterDid, data))
   },
 
-  async buildGetAcceptanceMechanismsRequest(submitterDid: Did, timestamp: number, version: string): Promise<string> {
+  async buildGetAcceptanceMechanismsRequest(submitterDid: Did, timestamp: number, version: string): Promise<LedgerRequest> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
@@ -695,7 +695,7 @@ const indy = {
     return [credDefId, JSON.parse(credDef)];
   },
 
-  async issuerCreateCredentialOffer(wh: WalletHandle, credDefId: CredDefId): Promise<string> {
+  async issuerCreateCredentialOffer(wh: WalletHandle, credDefId: CredDefId): Promise<CredOffer> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -477,6 +477,9 @@ const indy = {
   },
 
   async buildCredDefRequest(submitterDid: Did, credDef: CredDef): Promise<LedgerRequestResult> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
     return JSON.parse(await IndySdk.buildCredDefRequest(submitterDid, JSON.stringify(credDef)))
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -726,6 +726,28 @@ const indy = {
     return JSON.parse(await IndySdk.issuerCreateCredentialOffer(wh, credDefId))
   },
 
+  async issuerCreateCredential(
+    wh: WalletHandle,
+    credOffer: CredOffer,
+    credReq: CredReq,
+    credvalues: CredValues,
+    revRegId: RevRegId,
+    blobStorageReaderHandle: BlobReaderHandle
+  ): Promise<[Credential, CredRevocId, RevocRegDelta]> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+    const [credJson, revocId, revocRegDelta] = await IndySdk.issuerCreateCredential(
+      wh,
+      JSON.stringify(credOffer),
+      JSON.stringify(credReq),
+      JSON.stringify(credvalues),
+      revRegId,
+      blobStorageReaderHandle
+    )
+    return [JSON.parse(credJson), revocId, JSON.parse(revocRegDelta)]
+  },
+
   // blob_storage
 
   async openBlobStorageReader(type: string, tailsWriterConfig: TailsWriterConfig): Promise<BlobReaderHandle> {

--- a/src/index.js
+++ b/src/index.js
@@ -403,11 +403,28 @@ const indy = {
     return IndySdk.closePoolLedger(ph)
   },
 
+  // ledger
+
   async submitRequest(poolHandle: PoolHandle, request: LedgerRequest): Promise<LedgerRequestResult> {
     if (Platform.OS === 'ios') {
       return JSON.parse(await IndySdk.submitRequest(JSON.stringify(request), poolHandle))
     }
     return JSON.parse(await IndySdk.submitRequest(poolHandle, JSON.stringify(request)))
+  },
+
+  async signRequest(wh, submitterDid, request) {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`);
+    }
+    return JSON.parse((await IndySdk.signRequest(wh, submitterDid, JSON.stringify(request))));
+  },
+
+  async buildSchemaRequest(submitterDid: Did, data: string): Promise<LedgerRequest> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+
+    return IndySdk.buildSchemaRequest(submitterDid, JSON.stringify(data));
   },
 
   async buildGetSchemaRequest(submitterDid: Did, id: string): Promise<LedgerRequest> {
@@ -572,6 +589,27 @@ const indy = {
     )
   },
 
+  async appendTxnAuthorAgreementAcceptanceToRequest(request: LedgerRequest, text: string, version: string, taaDigest: string, mechanism: string, time: number): Promise<string> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+    return JSON.parse(await IndySdk.appendTxnAuthorAgreementAcceptanceToRequest(request, text, version, taaDigest, mechanism, time))
+  },
+
+  async buildGetTxnAuthorAgreementRequest(submitterDid: Did, data: string): Promise<string> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+    return JSON.parse(await IndySdk.buildGetTxnAuthorAgreementRequest(submitterDid, data))
+  },
+
+  async buildGetAcceptanceMechanismsRequest(submitterDid: Did, timestamp: number, version: string): Promise<string> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+    return JSON.parse(await IndySdk.buildGetAcceptanceMechanismsRequest(submitterDid, typeof timestamp == 'undefined' ? -1 : timestamp, typeof version == 'undefined' ? null : version))
+  },
+
   // non_secrets
 
   async addWalletRecord(wh: WalletHandle, type: string, id: string, value: string, tags: {}): Promise<void> {
@@ -613,6 +651,18 @@ const indy = {
   async closeWalletSearch(sh: WalletSearchHandle): Promise<void> {
     return IndySdk.closeWalletSearch(sh)
   },
+
+  // Anoncreds
+
+  async issuerCreateSchema(did: Did, name: string, version: string, attributes: string[]): Promise<[Schema, SchemaId]> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+
+    const [schemaId, schema] = await IndySdk.issuerCreateSchema(did, name, version, JSON.stringify(attributes));
+    return [schemaId, JSON.parse(schema)];
+  },
+
 }
 
 const indyErrors = {

--- a/src/index.js
+++ b/src/index.js
@@ -626,13 +626,6 @@ const indy = {
     return JSON.parse(await IndySdk.buildGetTxnAuthorAgreementRequest(submitterDid, data))
   },
 
-  async buildGetAcceptanceMechanismsRequest(submitterDid: Did, timestamp: number, version: string): Promise<LedgerRequest> {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
-    return JSON.parse(await IndySdk.buildGetAcceptanceMechanismsRequest(submitterDid, typeof timestamp == 'undefined' ? -1 : timestamp, typeof version == 'undefined' ? null : version))
-  },
-
   // non_secrets
 
   async addWalletRecord(wh: WalletHandle, type: string, id: string, value: string, tags: {}): Promise<void> {
@@ -701,15 +694,6 @@ const indy = {
     }
 
     return JSON.parse(await IndySdk.issuerCreateCredentialOffer(wh, credDefId));
-  },
-
-  async issuerCreateCredential(wh: WalletHandle, credOffer: CredOffer, credReq: CredReq, credValues: CredValues, revRegId: string, blobReaderHandle: number): Promise<[Cred, CredRevocId, RevocRegDelta]> {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
-
-    const [cred, credRevocId, revocRegDelta] = await IndySdk.issuerCreateCredential(wh, JSON.stringify(credOffer), JSON.stringify(credReq), revRegId, JSON.stringify(credValues), blobReaderHandle);
-    return [JSON.parse(cred), credRevocId, JSON.parse(revocRegDelta)];
   },
 
   // blob_storage

--- a/src/index.js
+++ b/src/index.js
@@ -412,7 +412,7 @@ const indy = {
     return JSON.parse(await IndySdk.submitRequest(poolHandle, JSON.stringify(request)))
   },
 
-  async signRequest(wh, submitterDid, request) {
+  async signRequest(wh: WalletHandle, submitterDid: Did, request: LedgerRequest) {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`);
     }
@@ -458,6 +458,10 @@ const indy = {
     }
     const [id, schema] = await IndySdk.parseGetSchemaResponse(JSON.stringify(getSchemaResponse))
     return [id, JSON.parse(schema)]
+  },
+
+  async buildCredDefRequest(submitterDid: Did, credDef: CredDef): Promise<LedgerRequestResult> {
+    return JSON.parse(await IndySdk.buildCredDefRequest(submitterDid, JSON.stringify(credDef)))
   },
 
   async buildGetCredDefRequest(submitterDid: Did, id: string): Promise<LedgerRequestResult> {
@@ -661,6 +665,15 @@ const indy = {
 
     const [schemaId, schema] = await IndySdk.issuerCreateSchema(did, name, version, JSON.stringify(attributes));
     return [schemaId, JSON.parse(schema)];
+  },
+
+  async issuerCreateAndStoreCredentialDef(wh: WalletHandle, issuerDid: Did, schema: Schema, tag: string, signatureType: string, config: {}): Promise<[CredDef, CredDefId]> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+
+    const [credDefId, credDef] = await IndySdk.issuerCreateAndStoreCredentialDef(wh, issuerDid, JSON.stringify(schema), tag, signatureType, JSON.stringify(config));
+    return [credDefId, JSON.parse(credDef)];
   },
 
 }

--- a/src/index.js
+++ b/src/index.js
@@ -207,6 +207,13 @@ export type CredReq = {
   nonce?: string,
 }
 
+export type CredValues = Record<string, CredValue>
+
+interface CredValue {
+  raw: string;
+  encoded: string; // Raw value as number in string
+}
+
 /**
  * Credential request metadata json for further processing of received form Issuer credential.
  */
@@ -217,12 +224,21 @@ export type CredReqMetadata = {}
  */
 export type RevRegDef = {}
 
+export type RevRegId = string;
+export type CredRevocId = string;
+export type RevocRegDelta = Record<string, unknown>;
+export type TailsWriterConfig = {
+  base_dir: string;
+  uri_pattern: string
+}
+
 export type Did = string
 
 export type Verkey = string
 
 export type WalletHandle = number
 export type PoolHandle = number
+export type BlobReaderHandle = number
 
 export type WalletRecord = {
   id: string,
@@ -416,7 +432,7 @@ const indy = {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`);
     }
-    return JSON.parse((await IndySdk.signRequest(wh, submitterDid, JSON.stringify(request))));
+    return JSON.parse(await IndySdk.signRequest(wh, submitterDid, JSON.stringify(request)));
   },
 
   async buildSchemaRequest(submitterDid: Did, data: string): Promise<LedgerRequest> {
@@ -424,7 +440,7 @@ const indy = {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
 
-    return IndySdk.buildSchemaRequest(submitterDid, JSON.stringify(data));
+    return JSON.parse(await IndySdk.buildSchemaRequest(submitterDid, JSON.stringify(data)));
   },
 
   async buildGetSchemaRequest(submitterDid: Did, id: string): Promise<LedgerRequest> {
@@ -676,6 +692,32 @@ const indy = {
     return [credDefId, JSON.parse(credDef)];
   },
 
+  async issuerCreateCredentialOffer(wh: WalletHandle, credDefId: CredDefId): Promise<string> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+
+    return JSON.parse(await IndySdk.issuerCreateCredentialOffer(wh, credDefId));
+  },
+
+  async issuerCreateCredential(wh: WalletHandle, credOffer: CredOffer, credReq: CredReq, credValues: CredValues, revRegId: string, blobReaderHandle: number): Promise<[Cred, CredRevocId, RevocRegDelta]> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+
+    const [cred, credRevocId, revocRegDelta] = await IndySdk.issuerCreateCredential(wh, JSON.stringify(credOffer), JSON.stringify(credReq), revRegId, JSON.stringify(credValues), blobReaderHandle);
+    return [JSON.parse(cred), credRevocId, JSON.parse(revocRegDelta)];
+  },
+
+  // blob_storage
+
+  async openBlobStorageReader(type: string, tailsWriterConfig: TailsWriterConfig): Promise<BlobReaderHandle> {
+    if (Platform.OS === 'ios') {
+      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
+    }
+
+    return JSON.parse(await IndySdk.openBlobStorageReader(type, JSON.stringify(tailsWriterConfig)));
+  },
 }
 
 const indyErrors = {

--- a/src/index.js
+++ b/src/index.js
@@ -483,7 +483,7 @@ const indy = {
     return JSON.parse(await IndySdk.buildCredDefRequest(submitterDid, JSON.stringify(credDef)))
   },
 
-  async buildGetCredDefRequest(submitterDid: Did, id: string): Promise<LedgerRequestResult> {
+  async buildGetCredDefRequest(submitterDid: Did, id: string): Promise<LedgerRequest> {
     return JSON.parse(await IndySdk.buildGetCredDefRequest(submitterDid, id))
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -476,7 +476,7 @@ const indy = {
     return [id, JSON.parse(schema)]
   },
 
-  async buildCredDefRequest(submitterDid: Did, credDef: CredDef): Promise<LedgerRequestResult> {
+  async buildCredDefRequest(submitterDid: Did, credDef: CredDef): Promise<LedgerRequest> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
@@ -686,7 +686,7 @@ const indy = {
 
   // Anoncreds
 
-  async issuerCreateSchema(did: Did, name: string, version: string, attributes: string[]): Promise<[Schema, SchemaId]> {
+  async issuerCreateSchema(did: Did, name: string, version: string, attributes: string[]): Promise<[SchemaId, Schema]> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }
@@ -702,7 +702,7 @@ const indy = {
     tag: string,
     signatureType: string,
     config: {}
-  ): Promise<[CredDef, CredDefId]> {
+  ): Promise<[CredDefId, CredDef]> {
     if (Platform.OS === 'ios') {
       throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
     }


### PR DESCRIPTION
List of methods added:
- signRequest 
- buildSchemaRequest
- buildCredDefRequest
- appendTxnAuthorAgreementAcceptanceToRequest
- buildGetTxnAuthorAgreementRequest
- buildGetAcceptanceMechanismsRequest
- issuerCreateSchema
- issuerCreateAndStoreCredentialDef
- issuerCreateCredentialOffer
- issuerCreateCredential
- openBlobStorageReader

Out of the above methods, the following were throwing errors:
- buildGetAcceptanceMechanismsRequest
- issuerCreateCredential

