### PR TITLE
FIX: Fixed log throw

### DIFF
--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -17,6 +17,7 @@
 package com.reactlibrary;
 
 import android.annotation.TargetApi;
+import android.util.Log;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;


### PR DESCRIPTION
A simple fix. You forgot to add the Log library on Android and it might not compile