### PR TITLE
fix: fixed hot reload on React Native

### DIFF
--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -67,10 +67,15 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
     private static Map<Integer, Pool> poolMap = new ConcurrentHashMap<>();
     private static Map<String, Integer> poolNameToHandleMap = new ConcurrentHashMap<>();
     private static Map<Integer, WalletSearch> searchMap = new ConcurrentHashMap<>();
+    private Map<Integer, CredentialsSearchForProofReq> credentialSearchMap;
+    // Java wrapper does not expose credentialSearchHandle
+    private int credentialSearchIterator = 0;
+
 
     public IndySdkModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
+        this.credentialSearchMap = new ConcurrentHashMap<>();
     }
 
     @Override

--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -28,6 +28,8 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 import org.hyperledger.indy.sdk.IndyException;
 import org.hyperledger.indy.sdk.ErrorCode;
@@ -60,21 +62,15 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
     private static final String TAG = "IndySdk";
     private final ReactApplicationContext reactContext;
 
-    private Map<Integer, Wallet> walletMap;
-    private Map<Integer, Pool> poolMap;
-    private Map<Integer, WalletSearch> searchMap;
-    private Map<Integer, CredentialsSearchForProofReq> credentialSearchMap;
-
-    // Java wrapper does not expose credentialSearchHandle
-    private int credentialSearchIterator = 0;
+    private static  Map<Integer, Wallet> walletMap = new ConcurrentHashMap<>();
+    private static Map<String, Integer> walletIdToHandleMap = new ConcurrentHashMap<>();
+    private static Map<Integer, Pool> poolMap = new ConcurrentHashMap<>();
+    private static Map<String, Integer> poolNameToHandleMap = new ConcurrentHashMap<>();
+    private static Map<Integer, WalletSearch> searchMap = new ConcurrentHashMap<>();
 
     public IndySdkModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
-        this.walletMap = new ConcurrentHashMap<>();
-        this.poolMap = new ConcurrentHashMap<>();
-        this.searchMap = new ConcurrentHashMap<>();
-        this.credentialSearchMap = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -97,8 +93,19 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void openWallet(String configJson, String credentialsJson, Promise promise) {
+        // Retrieve wallet id
+        Gson gson = new Gson();
+        JsonObject config = gson.fromJson(configJson, JsonObject.class);
+        String walletId = config.get("id").getAsString();
+
+        // If wallet is already opened, return open wallet
+        if (walletIdToHandleMap.containsKey(walletId)) {
+            promise.resolve(walletIdToHandleMap.get(walletId));
+        }
+
         try {
             Wallet wallet = Wallet.openWallet(configJson, credentialsJson).get();
+            walletIdToHandleMap.put(walletId, wallet.getWalletHandle());
             walletMap.put(wallet.getWalletHandle(), wallet);
             promise.resolve(wallet.getWalletHandle());
         } catch (Exception e) {
@@ -113,6 +120,15 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             Wallet wallet = walletMap.get(walletHandle);
             wallet.closeWallet().get();
             walletMap.remove(walletHandle);
+
+            // Remove wallet id mapping
+            for (Map.Entry<String, Integer> entry : walletIdToHandleMap.entrySet()) {
+                if (entry.getValue().equals(walletHandle)) {
+                    walletIdToHandleMap.remove(entry.getKey());
+                    break;
+                }
+            }
+
             promise.resolve(null);
         } catch (Exception e) {
             IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
@@ -407,9 +423,15 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void openPoolLedger(String configName, String poolConfig, Promise promise) {
         try {
-            Pool pool = Pool.openPoolLedger(configName, poolConfig).get();
-            poolMap.put(pool.getPoolHandle(), pool);
-            promise.resolve(pool.getPoolHandle());
+            if (poolNameToHandleMap.get(configName) != null){
+                promise.resolve(poolNameToHandleMap.get(configName));
+
+            } else {
+                Pool pool = Pool.openPoolLedger(configName, poolConfig).get();
+                poolMap.put(pool.getPoolHandle(), pool);
+                poolNameToHandleMap.put(configName, pool.getPoolHandle());
+                promise.resolve(pool.getPoolHandle());
+            }
         } catch (Exception e) {
             IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
             promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
@@ -422,6 +444,15 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             Pool pool = poolMap.get(handle);
             pool.closePoolLedger().get();
             poolMap.remove(handle);
+
+            // Remove pool id mapping
+            for (Map.Entry<String, Integer> entry : poolNameToHandleMap.entrySet()) {
+                if (entry.getValue().equals(handle)) {
+                    poolNameToHandleMap.remove(entry.getKey());
+                    break;
+                }
+            }
+            
             promise.resolve(null);
         } catch (Exception e) {
             IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);


### PR DESCRIPTION
This is a fix for RN Hot reload. I picked @TimoGlastra work and fixed it for iOS -it was not working- and Android.

The problem was that React Native reloads the native modules each time you reload the app and usually Metro will do that each time you save a file. Hence, the Wallet and Pool handles are lost on the native module, but they are still opened in libindy, and you got an error.

What I did is defining the wallet and the pool handles as static dictionaries, and store them in memory. They cannot be class members as IndySDK class is re-created each time RN reloads.

I fixed some deprecation warnings on iOS too. 