### PR TITLE
Feature/ios present-proof

### DIFF
--- a/android/src/main/java/com/reactlibrary/IndySdkModule.java
+++ b/android/src/main/java/com/reactlibrary/IndySdkModule.java
@@ -760,6 +760,45 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void proverSearchCredentialsForProofReq(int walletHandle, String proofRequest, String extraQuery, Promise promise) {
+      try {
+            int searchHandle = credentialSearchIterator++; 
+            Wallet wallet = walletMap.get(walletHandle);
+            CredentialsSearchForProofReq search = CredentialsSearchForProofReq.open(wallet, proofRequest, extraQuery).get();
+            credentialSearchMap.put(searchHandle, search);
+            promise.resolve(searchHandle);
+      } catch (Exception e) {
+          IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+          promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+      }
+    }
+
+    @ReactMethod
+    public void proverFetchCredentialsForProofReq(int searchHandle, String itemReferent, int count, Promise promise) {
+      try {
+          CredentialsSearchForProofReq search = credentialSearchMap.get(searchHandle);
+          String recordsJson = search.fetchNextCredentials(itemReferent, count).get();
+          promise.resolve(recordsJson);
+      } catch (Exception e) {
+          IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+          promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+      }
+    }
+
+    @ReactMethod
+    public void proverCloseCredentialsSearchForProofReq(int searchHandle, Promise promise) {
+        try {
+            CredentialsSearchForProofReq search = credentialSearchMap.get(searchHandle);
+            search.close();
+            credentialSearchMap.remove(searchHandle);
+            promise.resolve(null);
+        } catch (Exception e) {
+            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
+            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
+        }
+    }
+
+    @ReactMethod
     public void proverCreateProof(
       int walletHandle,
 			String proofRequest,
@@ -940,45 +979,6 @@ public class IndySdkModule extends ReactContextBaseJavaModule {
             WalletSearch search = searchMap.get(walletSearchHandle);
             WalletSearch.closeSearch(search);
             searchMap.remove(walletSearchHandle);
-            promise.resolve(null);
-        } catch (Exception e) {
-            IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-            promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-        }
-    }
-
-    @ReactMethod
-    public void proverSearchCredentialsForProofReq(int walletHandle, String proofRequest, String extraQuery, Promise promise) {
-      try {
-            int searchHandle = credentialSearchIterator++; 
-            Wallet wallet = walletMap.get(walletHandle);
-            CredentialsSearchForProofReq search = CredentialsSearchForProofReq.open(wallet, proofRequest, extraQuery).get();
-            credentialSearchMap.put(searchHandle, search);
-            promise.resolve(searchHandle);
-      } catch (Exception e) {
-          IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-          promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-      }
-    }
-
-    @ReactMethod
-    public void proverFetchCredentialsForProofReq(int searchHandle, String itemReferent, int count, Promise promise) {
-      try {
-          CredentialsSearchForProofReq search = credentialSearchMap.get(searchHandle);
-          String recordsJson = search.fetchNextCredentials(itemReferent, count).get();
-          promise.resolve(recordsJson);
-      } catch (Exception e) {
-          IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);
-          promise.reject(rejectResponse.getCode(), rejectResponse.toJson(), e);
-      }
-    }
-
-    @ReactMethod
-    public void proverCloseCredentialsSearchForProofReq(int searchHandle, Promise promise) {
-        try {
-            CredentialsSearchForProofReq search = credentialSearchMap.get(searchHandle);
-            search.close();
-            credentialSearchMap.remove(searchHandle);
             promise.resolve(null);
         } catch (Exception e) {
             IndySdkRejectResponse rejectResponse = new IndySdkRejectResponse(e);

--- a/ios/IndySdk.m
+++ b/ios/IndySdk.m
@@ -229,6 +229,25 @@ RCT_EXTERN_METHOD(proverGetCredentialsForProofReq: (NSString *)proofReqJSON wall
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(proverSearchCredentialsForProofReq: (nonnull NSNumber *)walletHandle
+                  proofReqJSON: (NSString *)proofReqJSON
+                  extraQueryJSON: (NSString *)extraQueryJSON
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+                  )
+
+RCT_EXTERN_METHOD(proverFetchCredentialsForProofReq: (nonnull NSNumber *)searchHandle
+                  itemReferent: (NSString *)itemReferent
+                  count: (nonnull NSNumber *)count
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+                  )
+
+RCT_EXTERN_METHOD(proverCloseCredentialsSearchForProofReq: (nonnull NSNumber *)searchHandle
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+                  )
+
 RCT_EXTERN_METHOD(proverCreateProofForRequest: (NSString *)proofReqJSON
                   requestedCredentialsJSON:(NSString *)requestedCredentialsJSON
                   masterSecretID:(NSString *)masterSecretID

--- a/ios/IndySdk.swift
+++ b/ios/IndySdk.swift
@@ -389,6 +389,27 @@ class IndySdk : NSObject {
       IndyAnoncreds.proverGetCredentials(forProofReq: proofReqJSON, walletHandle: whNumber, completion: completionWithString(resolve, reject))
     }
     
+    @obj func proverSearchCredentialsForProofReq(_ walletHandle: NSNumber,proofReqJSON: String, extraQuery: String,
+                                  resolver resolve: @escaping RCTPromiseResolveBlock,
+                                  rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+      let whNumber:Int32  = Int32(truncating:walletHandle)
+      IndyAnoncreds.proverSearchCredentials(forProofReq: proofReqJSON, extraQuery: extraQuery, walletHandle:whNumber, completion: completionWithIndyHandle(resolve, reject))
+    }
+
+    @objc func proverFetchCredentialsForProofReq(_ searchHandle:NSNumber, itemReferent: String, count: NSNumber, 
+                                  resolver resolve: @escaping RCTPromiseResolveBlock,
+                                  rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+      let shNumber:Int32 = Int32(truncating: searchHandle)
+      IndyAnoncreds.proverFetchCredentials(forProofReqItemReferent: shNumber, itemReferent: itemReferent, count:count, completion: completionWithString(resolve, reject))
+    }
+
+    @objc func proverCloseCredentialsSearchForProofReq(_ searchHandle:NSNumber, 
+    resolver resolve: @escaping RCTPromiseResolveBlock,
+                                  rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+      let shNumber:Int32 = int32(truncating: sh)
+      IndyAnoncreds.proverCloseCredentialsSearch(ForProofReqWithHandle: shNumber, completion: completion(resolve, reject))
+    }
+
     @objc func proverCreateProofForRequest(_ proofReqJSON: String, requestedCredentialsJSON: String, masterSecretID: String, schemasJSON: String, credentialDefsJSON: String, revocStatesJSON: String, walletHandle: NSNumber,
                                                resolver resolve: @escaping RCTPromiseResolveBlock,
                                                rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
@@ -404,7 +425,7 @@ class IndySdk : NSObject {
         completion: completionWithString(resolve, reject)
       )
     }
-    
+
     // non_secret
     
     @objc func addWalletRecord(_ wh: NSNumber, type: String, id: String, value: String, tags: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {

--- a/ios/IndySdk.swift
+++ b/ios/IndySdk.swift
@@ -389,25 +389,25 @@ class IndySdk : NSObject {
       IndyAnoncreds.proverGetCredentials(forProofReq: proofReqJSON, walletHandle: whNumber, completion: completionWithString(resolve, reject))
     }
     
-    @obj func proverSearchCredentialsForProofReq(_ walletHandle: NSNumber,proofReqJSON: String, extraQuery: String,
+    @objc func proverSearchCredentialsForProofReq(_ walletHandle: NSNumber,proofReqJSON: String, extraQueryJSON: String,
                                   resolver resolve: @escaping RCTPromiseResolveBlock,
                                   rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
       let whNumber:Int32  = Int32(truncating:walletHandle)
-      IndyAnoncreds.proverSearchCredentials(forProofReq: proofReqJSON, extraQuery: extraQuery, walletHandle:whNumber, completion: completionWithIndyHandle(resolve, reject))
+      IndyAnoncreds.proverSearchCredentials(forProofRequest: proofReqJSON, extraQueryJSON: extraQueryJSON, walletHandle:whNumber, completion: completionWithIndyHandle(resolve, reject))
     }
 
     @objc func proverFetchCredentialsForProofReq(_ searchHandle:NSNumber, itemReferent: String, count: NSNumber, 
                                   resolver resolve: @escaping RCTPromiseResolveBlock,
                                   rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
       let shNumber:Int32 = Int32(truncating: searchHandle)
-      IndyAnoncreds.proverFetchCredentials(forProofReqItemReferent: shNumber, itemReferent: itemReferent, count:count, completion: completionWithString(resolve, reject))
+      IndyAnoncreds.proverFetchCredentials(forProofReqItemReferent: itemReferent, searchHandle: shNumber, count:count, completion: completionWithString(resolve, reject))
     }
 
     @objc func proverCloseCredentialsSearchForProofReq(_ searchHandle:NSNumber, 
-    resolver resolve: @escaping RCTPromiseResolveBlock,
+                                  resolver resolve: @escaping RCTPromiseResolveBlock,
                                   rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-      let shNumber:Int32 = int32(truncating: sh)
-      IndyAnoncreds.proverCloseCredentialsSearch(ForProofReqWithHandle: shNumber, completion: completion(resolve, reject))
+      let shNumber:Int32 = Int32(truncating: searchHandle)
+      IndyAnoncreds.proverCloseCredentialsSearchForProofReq(withHandle: shNumber, completion: completion(resolve, reject))
     }
 
     @objc func proverCreateProofForRequest(_ proofReqJSON: String, requestedCredentialsJSON: String, masterSecretID: String, schemasJSON: String, credentialDefsJSON: String, revocStatesJSON: String, walletHandle: NSNumber,

--- a/ios/IndySdk.swift
+++ b/ios/IndySdk.swift
@@ -413,7 +413,7 @@ class IndySdk : NSObject {
     @objc func proverCreateProofForRequest(_ proofReqJSON: String, requestedCredentialsJSON: String, masterSecretID: String, schemasJSON: String, credentialDefsJSON: String, revocStatesJSON: String, walletHandle: NSNumber,
                                                resolver resolve: @escaping RCTPromiseResolveBlock,
                                                rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
-      let whNumber:Int32  = Int32(truncating:walletHandle)
+      let whNumber:Int32 = Int32(truncating:walletHandle)
       IndyAnoncreds.proverCreateProof(
         forRequest: proofReqJSON,
         requestedCredentialsJSON: requestedCredentialsJSON,

--- a/src/index.js
+++ b/src/index.js
@@ -480,9 +480,6 @@ const indy = {
   },
 
   async parseGetSchemaResponse(getSchemaResponse: LedgerRequestResult): Promise<[SchemaId, Schema]> {
-    if (Platform.OS === 'ios') {
-      return IndySdk.parseGetSchemaResponse(JSON.stringify(getSchemaResponse))
-    }
     const [id, schema] = await IndySdk.parseGetSchemaResponse(JSON.stringify(getSchemaResponse))
     return [id, JSON.parse(schema)]
   },

--- a/src/index.js
+++ b/src/index.js
@@ -565,13 +565,6 @@ const indy = {
     )
   },
 
-  async proverGetCredentials(wh: WalletHandle, filter: {} = {}): Promise<Credential[]> {
-    if (Platform.OS === 'ios') {
-      return JSON.parse(await IndySdk.proverGetCredentials(JSON.stringify(filter), wh))
-    }
-    return JSON.parse(await IndySdk.proverGetCredentials(wh, JSON.stringify(filter)))
-  },
-
   async proverGetCredential(wh: WalletHandle, credId: CredId): Promise<Credential> {
     if (Platform.OS === 'ios') {
       return JSON.parse(await IndySdk.proverGetCredential(credId, wh))
@@ -579,8 +572,23 @@ const indy = {
     return JSON.parse(await IndySdk.proverGetCredential(wh, credId))
   },
 
+  // TODO: add proverDeleteCredential() method
+
+  // NOTE: This method is deprecated because immediately returns all fetched credentials. Use proverSearchCredentials() to fetch records by small batches.
+  async proverGetCredentials(wh: WalletHandle, filter: {} = {}): Promise<Credential[]> {
+    if (Platform.OS === 'ios') {
+      return JSON.parse(await IndySdk.proverGetCredentials(JSON.stringify(filter), wh))
+    }
+    return JSON.parse(await IndySdk.proverGetCredentials(wh, JSON.stringify(filter)))
+  },
+
+  // TODO: add proverSearchCredentials() method
+  // TODO: add proverFetchCredentials() method
+  // TODO: add proverCloseCredentialsSearch() method
+
   // TODO Add return flow type.
   // It needs little investigation, because is doesn't seem to be same format as Credential stored in wallet.
+  // NOTE: This method is deprecated because immediately returns all fetched credentials. proverSearchCredentialsForProofReq to fetch records by small batches.
   async proverGetCredentialsForProofReq(wh: WalletHandle, proofRequest: ProofRequest) {
     if (Platform.OS == 'ios') {
       return JSON.parse(await IndySdk.proverGetCredentialsForProofReq(JSON.stringify(proofRequest), wh))
@@ -589,9 +597,6 @@ const indy = {
   },
 
   async proverSearchCredentialsForProofReq(wh: WalletHandle, proofRequest: ProofRequest, extraQuery: {}) {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
     return await IndySdk.proverSearchCredentialsForProofReq(
       wh,
       JSON.stringify(proofRequest),
@@ -600,16 +605,10 @@ const indy = {
   },
 
   async proverFetchCredentialsForProofReq(sh: number, itemReferent: string, count: number) {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
     return JSON.parse(await IndySdk.proverFetchCredentialsForProofReq(sh, itemReferent, count))
   },
 
   async proverCloseCredentialsSearchForProofReq(sh: number) {
-    if (Platform.OS === 'ios') {
-      throw new Error(`Unsupported operation! Platform: ${Platform.OS}`)
-    }
     return await IndySdk.proverCloseCredentialsSearchForProofReq(sh)
   },
 


### PR DESCRIPTION
Adds support for present-proof in iOS.
Fixed schema parsing in iOS.
Adds deprecation notice on relevant functions and corresponding method creation todos (as noted in indy-sdk).
Moves Java Presentation Search methods to Anoncreds' section.

Still need to add verify proof in iOS, but ended up needing to do that as a separate PR.