### PR TITLE
fix: matched searchCredsForProofReq method types to node wrapper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -598,7 +598,7 @@ const indy = {
     return await IndySdk.proverSearchCredentialsForProofReq(
       wh,
       JSON.stringify(proofRequest),
-      JSON.stringify(extraQuery ? extraQuery : {})
+      JSON.stringify(extraQuery ?? {})
     )
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -593,11 +593,12 @@ const indy = {
     return JSON.parse(await IndySdk.proverGetCredentialsForProofReq(wh, JSON.stringify(proofRequest)))
   },
 
-  async proverSearchCredentialsForProofReq(wh: WalletHandle, proofRequest: ProofRequest, extraQuery: {}) {
+  async proverSearchCredentialsForProofReq(wh: WalletHandle, proofRequest: ProofRequest, extraQuery: {} | null) {
+    //The NodeJS IndySDK wrapper differs from the Java and iOS wrappers in this call--it allows extraQuery to be a wql query object or null.
     return await IndySdk.proverSearchCredentialsForProofReq(
       wh,
       JSON.stringify(proofRequest),
-      JSON.stringify(extraQuery)
+      JSON.stringify(extraQuery ? extraQuery : {})
     )
   },
 


### PR DESCRIPTION
The IndySDK Node wrapper extraQuery type in the method `proverSearchCredentialsForProofReq` differs from the Android and iOS types. Node allows for the parameter to be either a JSON object or null, while Java requires it to be not-null:

```
Possible Unhandled Promise Rejection (id: 6):
Object {
  "indyBacktrace": "",
  "indyCode": 113,
  "indyMessage": "Error: Invalid structure
  Caused by: Invalid ProofRequestExtraQuery json has been passed
  Caused by: invalid type: null, expected a map at line 1 column 4
",
  "indyName": "CommonInvalidStructure",
  "message": "CommonInvalidStructure",
  "name": "IndyError",
}
```


Since the tests in AFJ use the Node wrapper they didn't uncover this issue until I tried to use it from a React Native perspective. I opted to adjust the method here to align with the Node types. I'd be happy to take a different approach if desired though.
